### PR TITLE
Move `score_neighbors()` out of `rank_neighbors()`

### DIFF
--- a/node.py
+++ b/node.py
@@ -456,6 +456,14 @@ class Peer:
             del self.order_orderinfo_mapping[order]
             order.holders.remove(self)
 
+    def score_neighbors(self) -> None:
+        """
+        This method calculates and updates the scores of my neighbors.
+        It needs to be run every time before making sharing order decisions.
+        :return: None
+        """
+        self.engine.score_neighbors(self)
+
     def rank_neighbors(self) -> List["Peer"]:
         """
         This method ranks neighbors according to their scores. It is called by internal method
@@ -463,21 +471,6 @@ class Peer:
         :return: a list peer instances ranked by the scores of their corresponding neighbor
         instances, from top to down.
         """
-        # HACK (weijiewu8): Consider whether to change the code in here, so as not to call
-        # score_neighbors() inside the function but keep it separate. If we do it, it will
-        # keep the functions independent to each other.
-        #
-        # However, there was a reason of calling it inside: This is simply the only place for
-        # this simulator to call score_neighbors().
-        #
-        # Probably will decide whether to change it later.
-        #
-        # I have been confused many times in writing unit tests when using rank_neighbors().
-        # If we make this change, we can remove lines like
-        # monkeypatch.setattr(engine, "score_neighbors", fake_score_neighbors)
-        # in the test files.
-
-        self.engine.score_neighbors(self)
         peer_list: List["Peer"] = list(self.peer_neighbor_mapping)
         peer_list.sort(
             key=lambda item: self.peer_neighbor_mapping[item].score, reverse=True

--- a/single_run.py
+++ b/single_run.py
@@ -463,6 +463,7 @@ class SingleRun:
         for peer in self.peer_full_set:
             if (self.cur_time - peer.birth_time) % self.engine.batch == 0:
                 peer.store_orders()
+                peer.score_neighbors()
                 (orders_to_share, neighbors_to_share) = peer.share_orders()
                 for internal_order in orders_to_share:
                     for beneficiary_peer in neighbors_to_share:

--- a/test/engine/test_tit_for_tat.py
+++ b/test/engine/test_tit_for_tat.py
@@ -32,25 +32,10 @@ def mock_random_sample(peers: List[Peer], number: int) -> List[Peer]:
     return list_of_peers[:number]
 
 
-def fake_score_neighbors(_peer):
-    """
-    This is a fake function to disable engine.score_neighbors(). In our current design
-    engine.score_neighbors() is called by peer.rank_neighbors(). In our unit tests here we will
-    need to call peer.rank_neighbors() but we have manually set scores for neighbors; we don't
-    want the function engine.score_neighbors() to change the scores again when it is called by
-    peer.rank_neighbors() so we use the fake function to disable the scores from being calculated
-    and updated again.
-    """
-    # HACK (weijiewu8): This is a temporary treatment. Consider changing engine.score_neighbors()
-    # to be moved out of peer.rank_neighbors() so they become independent of each other.
-    # If we do it, all fake_score_neighbors() can be deleted.
-
-
 class CaseType(NamedTuple):
     """
     This is a date type defined for the test cases in this module.
     The first six attributes are inputs to the test function, and the last two are expected outputs.
-
     """
 
     scenario: Scenario  # a scenario instance to create peers/orders
@@ -158,7 +143,6 @@ def test_tit_for_tat__no_zero_contributors(
         peer.peer_neighbor_mapping[neighbor_peers[i]].score = i + 300
 
     monkeypatch.setattr(random, "sample", mock_random_sample)
-    monkeypatch.setattr(engine, "score_neighbors", fake_score_neighbors)
 
     # Act
     selected_peer_set = engine_candidates.tit_for_tat(
@@ -215,7 +199,6 @@ def test_tit_for_tat__zero_contributors(scenario, engine, monkeypatch):
         peer.peer_neighbor_mapping[neighbor_peers[i]].score = i + 300
 
     monkeypatch.setattr(random, "sample", mock_random_sample)
-    monkeypatch.setattr(engine, "score_neighbors", fake_score_neighbors)
 
     # Act
     selected_peer_set = engine_candidates.tit_for_tat(

--- a/test/node/test_rank_neighbors.py
+++ b/test/node/test_rank_neighbors.py
@@ -10,21 +10,12 @@ from ..__init__ import SCENARIO_SAMPLE, ENGINE_SAMPLE, create_test_peers
 
 
 @pytest.mark.parametrize("scenario,engine", [(SCENARIO_SAMPLE, ENGINE_SAMPLE)])
-def test_rank_neighbors(scenario, engine, monkeypatch) -> None:
+def test_rank_neighbors(scenario, engine) -> None:
     """
-    This function tests rank_neighbors(). We disable score_neighbors() function which will
-    change the score of neighbors, and use a mocked one to replace it.
+    This function tests rank_neighbors().
     """
 
     # Arrange.
-
-    # Disable score_neighbors() function. Otherwise rank_neighbors() will change the scores that
-    # we have specifically set for this test.
-
-    def fake_score_neighbors(_peer):
-        pass
-
-    monkeypatch.setattr(engine, "score_neighbors", fake_score_neighbors)
 
     # create peer list
     peer_list: List[Peer] = create_test_peers(scenario, engine, 4)

--- a/test/node/test_scoring_system.py
+++ b/test/node/test_scoring_system.py
@@ -71,7 +71,7 @@ def test_scoring_system_penalty_a(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
     assert my_peer.peer_neighbor_mapping[neighbor].score == -13
@@ -121,7 +121,7 @@ def test_scoring_system_reward_a(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
     assert my_peer.peer_neighbor_mapping[neighbor].score == 2
@@ -174,7 +174,7 @@ def test_scoring_system_reward_b(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
     assert my_peer.peer_neighbor_mapping[neighbor].score == 3
@@ -223,7 +223,7 @@ def test_scoring_system_penalty_b(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
 
@@ -273,7 +273,7 @@ def test_scoring_system_reward_c(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
 
@@ -336,7 +336,7 @@ def test_scoring_system_reward_d(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
     assert my_peer.peer_neighbor_mapping[neighbor].score == 7
@@ -398,7 +398,7 @@ def test_scoring_system_reward_e(scenario, engine, monkeypatch) -> None:
     # store orders
     my_peer.store_orders()
     # calculate scores. The value equals to the last entry of the score sheet.
-    my_peer.rank_neighbors()
+    my_peer.score_neighbors()
 
     # Assert.
 


### PR DESCRIPTION
Fixes: #26 
In this PR I moved the call of `score_neighbors()` function out of the execution of `rank_neighbors()` function.
Originally the peer instance does not have `score_neighbors()` method; the function was implemented in `engine.py`. Every time a peer calls its method `rank_neighbors()`, the method will call `score_neighbors()` function in `engine.py`. The reason I designed like this was, `rank_neighbors()` is the only place that `score_neighbors()` is called.
However, the design was not straight forward and created burdens and tricks in unit tests. Also, it might be needed to call `score_neighbors()` directly in future extensions of the simulator. What's more, they are logically separated.  Manually combining them seems not a good design.
In this PR I separated these two functions. Now, a peer instance has one more method, `score_neighbors()` which will call `score_neighbors(peer)` from `engine.py`. Now `rank_neighbor(0` method does not call `score_neighbors()` any more. In the `single_run` instance, each time before making a sharing decision, a peer will need to proactively execute `peer.score_neighbors()`. 
This change simplifies a lot of unit tests cases where I removed mock functions, originally to mock the`score_neighbors()` inside `rank_neighbors()`.